### PR TITLE
[rust] request timeout

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "loqui_connection 0.0.1",
  "loqui_protocol 0.0.1",

--- a/rust/bench/client/src/main.rs
+++ b/rust/bench/client/src/main.rs
@@ -152,6 +152,7 @@ fn main() -> Result<(), Error> {
             let config = Config {
                 max_payload_size: ByteSize::kb(5000),
                 encoder: BytesEncoder {},
+                request_timeout: Duration::from_secs(5),
             };
             let address: SocketAddr = ADDRESS.parse().expect("Failed to parse address.");
             let client = await!(Client::connect(address, config)).expect("Failed to connect");

--- a/rust/examples/echo/src/main.rs
+++ b/rust/examples/echo/src/main.rs
@@ -79,6 +79,7 @@ async fn client_send_loop() {
     let config = ClientConfig {
         max_payload_size: ByteSize::kb(5000),
         encoder: StringEncoder {},
+        request_timeout: Duration::from_secs(1),
     };
 
     let address: SocketAddr = CLIENT_ADDRESS.parse().expect("Failed to parse address.");
@@ -98,7 +99,7 @@ async fn client_send_loop() {
                             info!("Received response: {}", response);
                         }
                         Err(e) => {
-                            error!("Request failed. error={:?}", e);
+                            error!("Request failed. error={}", e);
                         }
                     }
                 },
@@ -106,7 +107,7 @@ async fn client_send_loop() {
         }
 
         thread::sleep(Duration::from_secs(1));
-        client.close();
+        //client.close();
     }
 }
 

--- a/rust/examples/echo/src/main.rs
+++ b/rust/examples/echo/src/main.rs
@@ -107,7 +107,7 @@ async fn client_send_loop() {
         }
 
         thread::sleep(Duration::from_secs(1));
-        client.close();
+        //client.close();
     }
 }
 

--- a/rust/examples/echo/src/main.rs
+++ b/rust/examples/echo/src/main.rs
@@ -107,7 +107,7 @@ async fn client_send_loop() {
         }
 
         thread::sleep(Duration::from_secs(1));
-        //client.close();
+        client.close();
     }
 }
 

--- a/rust/loqui_client/Cargo.toml
+++ b/rust/loqui_client/Cargo.toml
@@ -10,6 +10,7 @@ loqui_connection = { path = "../loqui_connection" }
 failure = "0.1.1"
 log = "0.4"
 futures = "0.1.25"
+futures-timer = "0.1"
 tokio = { version = "0.1.16", features = ["async-await-preview"] }
 tokio-codec = "0.1"
 tokio-io = { version = "0.1.12" }

--- a/rust/loqui_client/src/client.rs
+++ b/rust/loqui_client/src/client.rs
@@ -1,5 +1,5 @@
 use crate::connection_handler::{ConnectionHandler, InternalEvent};
-use crate::waiter::Waiter;
+use crate::waiter::ResponseWaiter;
 use crate::Config;
 use failure::Error;
 use loqui_connection::{Encoder, Supervisor as SupervisedConnection};
@@ -28,7 +28,7 @@ impl<E: Encoder> Client<E> {
 
     /// Send a request to the server.
     pub async fn request(&self, payload: E::Encoded) -> Result<E::Decoded, Error> {
-        let (waiter, awaitable) = Waiter::new(self.config.request_timeout);
+        let (waiter, awaitable) = ResponseWaiter::new(self.config.request_timeout);
         let request = InternalEvent::Request { payload, waiter };
         self.connection.send(request)?;
         await!(awaitable)

--- a/rust/loqui_client/src/client.rs
+++ b/rust/loqui_client/src/client.rs
@@ -1,7 +1,9 @@
-use crate::connection_handler::{ConnectionHandler, InternalEvent};
+use crate::connection_handler::{ConnectionHandler, InternalEvent, Waiter};
 use crate::Config;
 use failure::Error;
+use futures::future::Future;
 use futures::sync::oneshot;
+use futures_timer::FutureExt;
 use loqui_connection::{Encoder, LoquiError, Supervisor as SupervisedConnection};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -10,15 +12,18 @@ use tokio::await;
 #[derive(Clone)]
 pub struct Client<E: Encoder> {
     connection: Arc<SupervisedConnection<ConnectionHandler<E>>>,
+    config: Arc<Config<E>>,
 }
 
 impl<E: Encoder> Client<E> {
     pub async fn connect(address: SocketAddr, config: Config<E>) -> Result<Client<E>, Error> {
         let config = Arc::new(config);
-        let handler_creator = move || ConnectionHandler::new(config.clone());
+        let handler_config = config.clone();
+        let handler_creator = move || ConnectionHandler::new(handler_config.clone());
         let connection = await!(SupervisedConnection::connect(address, handler_creator))?;
         let client = Self {
             connection: Arc::new(connection),
+            config,
         };
         Ok(client)
     }
@@ -26,11 +31,21 @@ impl<E: Encoder> Client<E> {
     /// Send a request to the server.
     pub async fn request(&self, payload: E::Encoded) -> Result<E::Decoded, Error> {
         let (waiter_tx, waiter_rx) = oneshot::channel();
-        let request = InternalEvent::Request { payload, waiter_tx };
+        let waiter = Waiter::new(waiter_tx, self.config.request_timeout);
+        let request = InternalEvent::Request { payload, waiter };
         self.connection.send(request)?;
-        match await!(waiter_rx) {
+        match await!(waiter_rx
+            .map_err(|oneshot::Canceled| Error::from(LoquiError::ConnectionClosed))
+            .timeout(self.config.request_timeout))
+        {
             Ok(result) => result,
-            Err(oneshot::Canceled) => Err(LoquiError::ConnectionClosed.into()),
+            Err(error) => {
+                if let Some(_error) = error.downcast_ref::<std::io::Error>() {
+                    Err(LoquiError::RequestTimeout.into())
+                } else {
+                    Err(error.into())
+                }
+            }
         }
     }
 

--- a/rust/loqui_client/src/config.rs
+++ b/rust/loqui_client/src/config.rs
@@ -1,8 +1,10 @@
 use bytesize::ByteSize;
 use loqui_connection::Encoder;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct Config<E: Encoder> {
     pub encoder: E,
     pub max_payload_size: ByteSize,
+    pub request_timeout: Duration,
 }

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -14,11 +14,32 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::await;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 use tokio_codec::Framed;
+
+#[derive(Debug)]
+pub struct Waiter<Decoded: DeserializeOwned + Send + Sync> {
+    tx: OneShotSender<Result<Decoded, Error>>,
+    deadline: Instant,
+}
+
+impl<Decoded: DeserializeOwned + Send + Sync> Waiter<Decoded> {
+    pub fn new(tx: OneShotSender<Result<Decoded, Error>>, timeout: Duration) -> Self {
+        Self {
+            tx,
+            deadline: Instant::now() + timeout,
+        }
+    }
+
+    fn notify(self, result: Result<Decoded, Error>) {
+        if let Err(_e) = self.tx.send(result) {
+            warn!("Waiter is no longer listening.")
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum InternalEvent<Encoded, Decoded>
@@ -28,7 +49,7 @@ where
 {
     Request {
         payload: Encoded,
-        waiter_tx: OneShotSender<Result<Decoded, Error>>,
+        waiter: Waiter<Decoded>,
     },
     Push {
         payload: Encoded,
@@ -36,7 +57,7 @@ where
 }
 
 pub struct ConnectionHandler<E: Encoder> {
-    waiters: HashMap<u32, OneShotSender<Result<E::Decoded, Error>>>,
+    waiters: HashMap<u32, Waiter<E::Decoded>>,
     config: Arc<Config<E>>,
 }
 
@@ -140,9 +161,9 @@ impl<E: Encoder> Handler for ConnectionHandler<E> {
         let TransportOptions { encoding, .. } = transport_options;
         // Forward Request and Push events to the connection so it can send them to the server.
         match event {
-            InternalEvent::Request { payload, waiter_tx } => {
+            InternalEvent::Request { payload, waiter } => {
                 let sequence_id = id_sequence.next();
-                self.handle_request(payload, encoding, sequence_id, waiter_tx)
+                self.handle_request(payload, encoding, sequence_id, waiter)
             }
             InternalEvent::Push { payload } => self.handle_push(payload, encoding),
         }
@@ -171,12 +192,18 @@ impl<E: Encoder> ConnectionHandler<E> {
         payload: E::Encoded,
         encoding: &'static str,
         sequence_id: u32,
-        waiter_tx: OneShotSender<Result<E::Decoded, Error>>,
+        waiter: Waiter<E::Decoded>,
     ) -> Option<LoquiFrame> {
+        use std::thread;
+        if waiter.deadline < Instant::now() {
+            debug!("Timeout.");
+            return None;
+        }
+
         match self.config.encoder.encode(encoding, payload) {
             Ok((payload, compressed)) => {
                 // Store the waiter so we can notify it when we get a response.
-                self.waiters.insert(sequence_id, waiter_tx);
+                self.waiters.insert(sequence_id, waiter);
                 let request = Request {
                     payload,
                     sequence_id,
@@ -185,7 +212,7 @@ impl<E: Encoder> ConnectionHandler<E> {
                 Some(request.into())
             }
             Err(error) => {
-                notify_waiter(waiter_tx, Err(error.into()));
+                waiter.notify(Err(error.into()));
                 None
             }
         }
@@ -198,13 +225,13 @@ impl<E: Encoder> ConnectionHandler<E> {
             payload,
         } = response;
         match self.waiters.remove(&sequence_id) {
-            Some(waiter_tx) => {
+            Some(waiter) => {
                 let response = self.config.encoder.decode(
                     transport_options.encoding,
                     is_compressed(flags),
                     payload,
                 );
-                notify_waiter(waiter_tx, response);
+                waiter.notify(response);
             }
             None => {
                 warn!("No waiter for sequence_id. sequence_id={:?}", sequence_id);
@@ -219,12 +246,12 @@ impl<E: Encoder> ConnectionHandler<E> {
             ..
         } = error;
         match self.waiters.remove(&sequence_id) {
-            Some(waiter_tx) => {
+            Some(waiter) => {
                 // payload is always a string
                 let result = String::from_utf8(payload)
                     .map_err(Error::from)
                     .and_then(|reason| Err(err_msg(reason)));
-                notify_waiter(waiter_tx, result);
+                waiter.notify(result);
             }
             None => {
                 warn!("No waiter for sequence_id. sequence_id={:?}", sequence_id);
@@ -283,14 +310,5 @@ impl<E: Encoder> ConnectionHandler<E> {
             ping_interval,
             transport_options,
         })
-    }
-}
-
-fn notify_waiter<Decoded: DeserializeOwned + Send + Sync>(
-    waiter_tx: OneShotSender<Result<Decoded, Error>>,
-    result: Result<Decoded, Error>,
-) {
-    if let Err(_e) = waiter_tx.send(result) {
-        warn!("Waiter is no longer listening.")
     }
 }

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -200,7 +200,7 @@ impl<E: Encoder> ConnectionHandler<E> {
         waiter: Waiter<E::Decoded>,
     ) -> Option<LoquiFrame> {
         if waiter.deadline < Instant::now() {
-            debug!("Timeout.");
+            waiter.notify(Err(LoquiError::RequestTimeout.into()));
             return None;
         }
 

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -179,7 +179,7 @@ impl<E: Encoder> ConnectionHandler<E> {
         sequence_id: u32,
         waiter: ResponseWaiter<E::Decoded>,
     ) -> Option<LoquiFrame> {
-        if waiter.deadline < Instant::now() {
+        if waiter.deadline <= Instant::now() {
             waiter.notify(Err(LoquiError::RequestTimeout.into()));
             return None;
         }

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -149,8 +149,9 @@ impl<E: Encoder> Handler for ConnectionHandler<E> {
 
     fn handle_ping(&mut self) {
         // Use to sweep dead waiters.
+        let now = Instant::now();
         self.waiters
-            .retain(|_sequence_id, waiter| waiter.deadline > Instant::now());
+            .retain(|_sequence_id, waiter| waiter.deadline > now);
     }
 }
 

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -218,7 +218,7 @@ impl<E: Encoder> ConnectionHandler<E> {
                 waiter.notify(response);
             }
             None => {
-                warn!("No waiter for sequence_id. sequence_id={:?}", sequence_id);
+                debug!("No waiter for sequence_id. sequence_id={:?}", sequence_id);
             }
         }
     }

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -1,7 +1,7 @@
+use crate::waiter::Waiter;
 use crate::Config;
 use bytesize::ByteSize;
 use failure::{err_msg, Error};
-use futures::sync::oneshot::Sender as OneShotSender;
 use loqui_connection::handler::{DelegatedFrame, Handler, Ready, TransportOptions};
 use loqui_connection::{Encoder, IdSequence, LoquiError, ReaderWriter};
 use loqui_protocol::frames::{
@@ -19,27 +19,6 @@ use tokio::await;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 use tokio_codec::Framed;
-
-#[derive(Debug)]
-pub struct Waiter<Decoded: DeserializeOwned + Send + Sync> {
-    tx: OneShotSender<Result<Decoded, Error>>,
-    deadline: Instant,
-}
-
-impl<Decoded: DeserializeOwned + Send + Sync> Waiter<Decoded> {
-    pub fn new(tx: OneShotSender<Result<Decoded, Error>>, timeout: Duration) -> Self {
-        Self {
-            tx,
-            deadline: Instant::now() + timeout,
-        }
-    }
-
-    fn notify(self, result: Result<Decoded, Error>) {
-        if let Err(_e) = self.tx.send(result) {
-            warn!("Waiter is no longer listening.")
-        }
-    }
-}
 
 #[derive(Debug)]
 pub enum InternalEvent<Encoded, Decoded>

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -1,4 +1,4 @@
-use crate::waiter::Waiter;
+use crate::waiter::ResponseWaiter;
 use crate::Config;
 use bytesize::ByteSize;
 use failure::{err_msg, Error};
@@ -28,7 +28,7 @@ where
 {
     Request {
         payload: Encoded,
-        waiter: Waiter<Decoded>,
+        waiter: ResponseWaiter<Decoded>,
     },
     Push {
         payload: Encoded,
@@ -36,7 +36,7 @@ where
 }
 
 pub struct ConnectionHandler<E: Encoder> {
-    waiters: HashMap<u32, Waiter<E::Decoded>>,
+    waiters: HashMap<u32, ResponseWaiter<E::Decoded>>,
     config: Arc<Config<E>>,
 }
 
@@ -176,7 +176,7 @@ impl<E: Encoder> ConnectionHandler<E> {
         payload: E::Encoded,
         encoding: &'static str,
         sequence_id: u32,
-        waiter: Waiter<E::Decoded>,
+        waiter: ResponseWaiter<E::Decoded>,
     ) -> Option<LoquiFrame> {
         if waiter.deadline < Instant::now() {
             waiter.notify(Err(LoquiError::RequestTimeout.into()));

--- a/rust/loqui_client/src/connection_handler.rs
+++ b/rust/loqui_client/src/connection_handler.rs
@@ -76,7 +76,7 @@ impl<E: Encoder> Handler for ConnectionHandler<E> {
             match await!(reader.next()) {
                 Some(Ok(UpgradeFrame::Response)) => Ok(writer.reunite(reader)?.into_inner()),
                 Some(Ok(frame)) => Err(LoquiError::InvalidUpgradeFrame { frame }.into()),
-                Some(Err(e)) => Err(e.into()),
+                Some(Err(e)) => Err(e),
                 None => Err(LoquiError::TcpStreamClosed.into()),
             }
         }

--- a/rust/loqui_client/src/lib.rs
+++ b/rust/loqui_client/src/lib.rs
@@ -6,6 +6,7 @@ extern crate log;
 mod client;
 mod config;
 mod connection_handler;
+mod waiter;
 
 pub use client::Client;
 pub use config::Config;

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -1,0 +1,29 @@
+use failure::Error;
+use futures::sync::oneshot::{self, Receiver, Sender};
+use serde::{de::DeserializeOwned};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub struct Waiter<Decoded: DeserializeOwned + Send + Sync> {
+    tx: Sender<Result<Decoded, Error>>,
+    pub deadline: Instant,
+}
+
+impl<Decoded: DeserializeOwned + Send + Sync> Waiter<Decoded> {
+    pub fn new(timeout: Duration) -> (Self, Receiver<Result<Decoded, Error>>) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                tx,
+                deadline: Instant::now() + timeout,
+            },
+            rx,
+        )
+    }
+
+    pub fn notify(self, result: Result<Decoded, Error>) {
+        if let Err(_e) = self.tx.send(result) {
+            warn!("Waiter is no longer listening.")
+        }
+    }
+}

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -16,8 +16,8 @@ pub struct ResponseWaiter<Decoded: DeserializeOwned + Send + Sync> {
 impl<Decoded: DeserializeOwned + Send + Sync> ResponseWaiter<Decoded> {
     /// Creates a new response waiter that will wait until the specified timeout.
     /// The returned future will resolve when someone calls waiter.notify().
-    /// The returned future will either return the Decoded object, a timeout error, or another
-    /// error from the server.
+    /// The returned future will either return the `Decoded` `struct`, a `LoquiError::RequestTimeout`,
+    /// error, or another error from the server.
     ///
     /// # Arguments
     /// * `timeout` - the `Duration` of time to wait before giving up on the request

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -16,11 +16,15 @@ pub struct ResponseWaiter<Decoded: DeserializeOwned + Send + Sync> {
 impl<Decoded: DeserializeOwned + Send + Sync> ResponseWaiter<Decoded> {
     /// Creates a new response waiter that will wait until the specified timeout.
     /// The returned future will resolve when someone calls waiter.notify().
-    /// The returned future will either return the `Decoded` `struct`, a `LoquiError::RequestTimeout`,
-    /// error, or another error from the server.
     ///
     /// # Arguments
+    ///
     /// * `timeout` - the `Duration` of time to wait before giving up on the request
+    ///
+    /// # Errors
+    ///
+    /// `LoquiError::RequestTimeout` or some other error from the server.
+    ///
     pub fn new(timeout: Duration) -> (Self, impl Future<Item = Decoded, Error = Error>) {
         let (tx, rx) = oneshot::channel::<Result<Decoded, Error>>();
 

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -55,6 +55,7 @@ impl<Decoded: DeserializeOwned + Send + Sync> ResponseWaiter<Decoded> {
         )
     }
 
+    /// Notify the waiter that a result was received.
     pub fn notify(self, result: Result<Decoded, Error>) {
         if let Err(_e) = self.tx.send(result) {
             warn!("Waiter is no longer listening.")

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -1,6 +1,10 @@
 use failure::Error;
-use futures::sync::oneshot::{self, Receiver, Sender};
-use serde::{de::DeserializeOwned};
+use futures::future::Future;
+use futures::sync::oneshot::{self, Sender};
+use futures_timer::FutureExt;
+use loqui_connection::LoquiError;
+use serde::de::DeserializeOwned;
+use std::io;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
@@ -10,14 +14,42 @@ pub struct Waiter<Decoded: DeserializeOwned + Send + Sync> {
 }
 
 impl<Decoded: DeserializeOwned + Send + Sync> Waiter<Decoded> {
-    pub fn new(timeout: Duration) -> (Self, Receiver<Result<Decoded, Error>>) {
-        let (tx, rx) = oneshot::channel();
+    /// Creates a new waiter that wait for the specified timeout. Awaiting on the returned future
+    /// will either return the Decoded object, a timeout error, or another error from the server.
+    ///
+    /// # Arguments
+    /// * `timeout` - the `Duration` of time to wait before giving up on the request
+    pub fn new(timeout: Duration) -> (Self, impl Future<Item = Decoded, Error = Error>) {
+        let (tx, rx) = oneshot::channel::<Result<Decoded, Error>>();
+
+        let awaitable = rx
+            .map_err(|_canceled| Error::from(LoquiError::ConnectionClosed))
+            .timeout(timeout)
+            .map_err(|error| match error.downcast::<io::Error>() {
+                Ok(error) => {
+                    // Change the timeout error back into one we like.
+                    if error.kind() == io::ErrorKind::TimedOut {
+                        LoquiError::RequestTimeout.into()
+                    } else {
+                        error.into()
+                    }
+                }
+                Err(error) => error.into(),
+            })
+            // Collapses the Result<Result<Decoded, Error>> into a Result<Decoded, Error>
+            .then(
+                |result: Result<Result<Decoded, Error>, Error>| match result {
+                    Ok(result) => result,
+                    Err(error) => Err(error.into()),
+                },
+            );
+
         (
             Self {
                 tx,
                 deadline: Instant::now() + timeout,
             },
-            rx,
+            awaitable,
         )
     }
 

--- a/rust/loqui_client/src/waiter.rs
+++ b/rust/loqui_client/src/waiter.rs
@@ -8,14 +8,16 @@ use std::io;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
-pub struct Waiter<Decoded: DeserializeOwned + Send + Sync> {
+pub struct ResponseWaiter<Decoded: DeserializeOwned + Send + Sync> {
     tx: Sender<Result<Decoded, Error>>,
     pub deadline: Instant,
 }
 
-impl<Decoded: DeserializeOwned + Send + Sync> Waiter<Decoded> {
-    /// Creates a new waiter that wait for the specified timeout. Awaiting on the returned future
-    /// will either return the Decoded object, a timeout error, or another error from the server.
+impl<Decoded: DeserializeOwned + Send + Sync> ResponseWaiter<Decoded> {
+    /// Creates a new response waiter that will wait until the specified timeout.
+    /// The returned future will resolve when someone calls waiter.notify().
+    /// The returned future will either return the Decoded object, a timeout error, or another
+    /// error from the server.
     ///
     /// # Arguments
     /// * `timeout` - the `Duration` of time to wait before giving up on the request

--- a/rust/loqui_connection/src/error.rs
+++ b/rust/loqui_connection/src/error.rs
@@ -42,6 +42,8 @@ pub enum LoquiError {
     EventReceiveError,
     #[fail(display = "Ready send failed.")]
     ReadySendFailed,
+    #[fail(display = "Request timeout.")]
+    RequestTimeout,
 }
 
 pub enum LoquiErrorCode {

--- a/rust/loqui_connection/src/event_handler.rs
+++ b/rust/loqui_connection/src/event_handler.rs
@@ -114,11 +114,12 @@ impl<H: Handler> EventHandler<H> {
         Ok(None)
     }
 
-    fn handle_ping_frame(&self, ping: Ping) -> MaybeFrameResult {
+    fn handle_ping_frame(&mut self, ping: Ping) -> MaybeFrameResult {
         let pong = Pong {
             flags: ping.flags,
             sequence_id: ping.sequence_id,
         };
+        self.handler.handle_ping();
         Ok(Some(pong.into()))
     }
 

--- a/rust/loqui_connection/src/handler.rs
+++ b/rust/loqui_connection/src/handler.rs
@@ -71,6 +71,8 @@ pub trait Handler: Send + Sync + 'static {
         id_sequence: &mut IdSequence,
         transport_options: &TransportOptions,
     ) -> Option<LoquiFrame>;
+    /// Periodic callback that fires whenever a ping fires.
+    fn handle_ping(&mut self);
 }
 
 impl From<Push> for DelegatedFrame {

--- a/rust/loqui_server/src/connection_handler.rs
+++ b/rust/loqui_server/src/connection_handler.rs
@@ -114,6 +114,8 @@ impl<R: RequestHandler<E>, E: Encoder> Handler for ConnectionHandler<R, E> {
     ) -> Option<LoquiFrame> {
         None
     }
+
+    fn handle_ping(&mut self) {}
 }
 
 async fn handle_push<E: Encoder, R: RequestHandler<E>>(


### PR DESCRIPTION
This adds request timeouts to the rust client.

Two things happening here:
1. Moved the `waiter_tx` into a `ResponseWaiter` with some convenience functions. It also masks that it's a oneshot.
2. Added a `handle_ping` callback to `Handler` that will be called every time a ping is sent. We use this to sweep the `waiters` map.