### PR TITLE
Add missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
     packages=['loqui'],
     ext_modules=extensions,
     tests_require=['pytest'],
+    install_requires=['six==1.12.0'],
     setup_requires=['pytest-runner']
 )


### PR DESCRIPTION
Parts of the python package makes use of the [six](https://pypi.org/project/six/) package but this package does not have six specified as a required dependency, this PR resolves that issue.